### PR TITLE
Add codex documenting session actions

### DIFF
--- a/codex.md
+++ b/codex.md
@@ -1,0 +1,60 @@
+# Codex
+
+This document summarizes the actions and key logs from the current session.
+
+## Repository Navigation
+
+```bash
+ls
+```
+```
+LICENSE  README.md  data  notebooks  requirements.txt
+```
+
+```bash
+find . -name AGENTS.md -print
+```
+```
+# (no output)
+```
+
+## Environment Diagnostics
+
+```bash
+python --version
+```
+```
+Python 3.12.10
+```
+
+```bash
+which python
+```
+```
+/root/.pyenv/shims/python
+```
+
+### PATH before fix
+```bash
+echo $PATH
+```
+```
+/root/.nvm/versions/node/v20.19.4/bin:/root/.pyenv/shims:3943PYENV_ROOT/shims:/root/.pyenv/bin:...
+```
+
+### PATH fix
+```bash
+export PATH="${PATH//3943PYENV_ROOT/$PYENV_ROOT}"
+```
+
+### PATH after fix
+```bash
+echo $PATH
+```
+```
+/root/.nvm/versions/node/v20.19.4/bin:/root/.pyenv/shims:/root/.pyenv/shims:/root/.pyenv/bin:...
+```
+
+## Notes
+- The repository currently lacks the extensive `doc/` directory referenced in the provided list.
+


### PR DESCRIPTION
## Summary
- Add `codex.md` summarizing repository navigation, environment diagnostics, and PATH cleanup

## Testing
- `python --version`
- `which python`


------
https://chatgpt.com/codex/tasks/task_e_689d9cb390e88322a3a35ca0ea42dffd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a session log document summarizing repository structure, environment details (Python version and interpreter path), and PATH diagnostics with before/after values and the described substitution approach.
  * Includes command/output snippets for navigation and environment checks.
  * Notes clarify that the referenced doc directory is currently absent.
  * No changes to user-facing features or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->